### PR TITLE
Appease the oh so finicky flake8

### DIFF
--- a/fstring_builder/__init__.py
+++ b/fstring_builder/__init__.py
@@ -1,3 +1,3 @@
-from .replacement_field import ReplacementField
-from .fstring import FormatString
-from .enums import *
+from .replacement_field import ReplacementField  # noqa: F401
+from .fstring import FormatString  # noqa: F401
+from .enums import *  # noqa: F401,F403

--- a/fstring_builder/fstring.py
+++ b/fstring_builder/fstring.py
@@ -1,5 +1,6 @@
 """fstring_builder.fstring"""
 from typing import Union
+
 from .replacement_field import ReplacementField
 
 

--- a/fstring_builder/replacement_field.py
+++ b/fstring_builder/replacement_field.py
@@ -1,7 +1,7 @@
 """fstring_builder.fstring_field"""
 from typing import Optional, Union, TypeVar
 
-from .enums import *
+from .enums import Conversion, Sign, Align, Grouping, Type
 
 TField = TypeVar("TField", bound="ReplacementField")
 

--- a/tests/test_replacement_field.py
+++ b/tests/test_replacement_field.py
@@ -1,6 +1,6 @@
 import pytest
 from fstring_builder.replacement_field import ReplacementField
-from fstring_builder.enums import *
+from fstring_builder.enums import Align, Grouping
 
 
 def test_replacement_field_constructor():


### PR DESCRIPTION
Apparently '*' imports are an anti-pattern.
I still want to use it in the __init__ file though